### PR TITLE
Add requirejs config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,11 @@
         <upstream.file>soundmanagerv297a-20131201.zip</upstream.file>
         <upstream.url>http://www.schillmania.com/projects/soundmanager2/download/</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
+        <requirejs>{
+            "paths": {
+                "SoundManager": "script/soundmanager2-nodebug"
+            }
+        }</requirejs>
     </properties>
 
     <build>


### PR DESCRIPTION
Added the configuration required by the webjars-locator to create the requirejs config.

PS: A somewhat related problem that I noticed while testing this -> if the version differs from the upstream.version, the locator will generate incorrect paths for requirejs. To fix this I would set the destination folder to `<destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${version}</destDir>` instead. I tested on local and the requirejs config then works correctly. However I don't know if this has any negative effects on other things so I did not include it in the patch. As long as the version and upstream.version are identical all should be good.
